### PR TITLE
Fix Circle-CI project bootstrap issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: sudo apt-get install -y doxygen graphviz
+          command: sudo apt-get install -y autoconf automake libtool doxygen graphviz
 
       - run:
           name: Bootstrap


### PR DESCRIPTION
The bootstrap script requires autoconf, automake, and libtool to run autoreconf. Added these packages to the apt-get install command.