### PR TITLE
Remove chained APIs by changing return types to void

### DIFF
--- a/tuna/tuna.c
+++ b/tuna/tuna.c
@@ -114,7 +114,7 @@ tuna_stats_mom(const tuna_stats* const t,
     return t->n;
 }
 
-tuna_stats*
+void
 tuna_stats_obs(tuna_stats* const t,
                const double x)
 {
@@ -129,10 +129,9 @@ tuna_stats_obs(tuna_stats* const t,
         t->m = x;
         t->s = 0;
     }
-    return t;
 }
 
-tuna_stats*
+void
 tuna_stats_nobs(tuna_stats* const t,
                 const double* x,
                 size_t N)
@@ -141,10 +140,9 @@ tuna_stats_nobs(tuna_stats* const t,
     for (i = N; i -- > 0 ;) {
         tuna_stats_obs(t, *x++);
     }
-    return t;
 }
 
-tuna_stats*
+void
 tuna_stats_merge(tuna_stats* const dst,
                  const tuna_stats* const src)
 {
@@ -161,7 +159,6 @@ tuna_stats_merge(tuna_stats* const dst,
                        + ((dM * dM) * (dst->n * src->n)) / total;
         dst->n       = total;
     }
-    return dst;
 }
 
 /**
@@ -182,7 +179,7 @@ enforce_lt(double* const a, double* const b)
     }
 }
 
-tuna_chunk*
+void
 tuna_chunk_obs(tuna_chunk* const k,
                double t)
 {
@@ -209,11 +206,9 @@ tuna_chunk_obs(tuna_chunk* const k,
     /* track any statistics.  This effectively provides some "start up" */
     /* or "burn in" period in addition to preventing highly improbable  */
     /* observations from unduly inflating the discovered variability.   */
-
-    return k;
 }
 
-tuna_stats*
+void
 tuna_chunk_merge(tuna_stats* const s,
                  const tuna_chunk* const k)
 {
@@ -225,7 +220,6 @@ tuna_chunk_merge(tuna_stats* const s,
             break;
         }
     }
-    return s;
 }
 
 /**

--- a/tuna/tuna.h
+++ b/tuna/tuna.h
@@ -144,7 +144,7 @@ tuna_stats_mom(const tuna_stats* t,
                double* var);
 
 /** Accumulate a new observation \c x into statistics \c t. */
-tuna_stats*
+void
 tuna_stats_obs(tuna_stats* t,
                const double x);
 
@@ -152,13 +152,13 @@ tuna_stats_obs(tuna_stats* t,
  * Accumulate \c N distinct observations <code>x[0]</code>, ...,
  * <code>x[N-1]</code> into statistics \c t.
  */
-tuna_stats*
+void
 tuna_stats_nobs(tuna_stats* t,
                 const double* x,
                 size_t N);
 
 /** Incorporate running information from another instance. */
-tuna_stats*
+void
 tuna_stats_merge(tuna_stats* dst,
                  const tuna_stats* src);
 
@@ -185,7 +185,7 @@ typedef struct tuna_chunk {
  * but it might also be some other performance metric.  Regardless of what is
  * chosen, smaller should mean better.
  */
-tuna_chunk*
+void
 tuna_chunk_obs(tuna_chunk* k,
                double t);
 
@@ -193,7 +193,7 @@ tuna_chunk_obs(tuna_chunk* k,
  * Incorporate all cost information recorded about chunk \c k into \c s,
  * including any outliers otherwise discarded from consideration.
  */
-tuna_stats*
+void
 tuna_chunk_merge(tuna_stats* s,
                  const tuna_chunk* k);
 


### PR DESCRIPTION
Changed the following functions from returning pointers to void:
- tuna_stats_obs: tuna_stats* -> void
- tuna_stats_nobs: tuna_stats* -> void
- tuna_stats_merge: tuna_stats* -> void
- tuna_chunk_obs: tuna_chunk* -> void
- tuna_chunk_merge: tuna_stats* -> void

These functions previously returned their mutated input arguments,
enabling method chaining patterns. However, this pattern was not
used anywhere in the codebase, and removing it simplifies the API
and prevents potentially confusing chained calls.

Fixes #29