### PR TITLE
Extract outlier count into TUNA_NOUTLIERS constant

### DIFF
--- a/tests/chunk.c
+++ b/tests/chunk.c
@@ -13,7 +13,7 @@
 #include "fct.h"
 
 // Many tests rely on having a known number of outliers
-enum { noutliers = 3 };
+#define noutliers TUNA_NOUTLIERS
 
 FCT_BGN()
 {

--- a/tuna/tuna.h
+++ b/tuna/tuna.h
@@ -170,13 +170,20 @@ tuna_stats_merge(tuna_stats* dst,
  */
 
 /**
+ * Number of outliers tracked per chunk.
+ * Tuna omits this many worst outliers from consideration when computing
+ * statistics, forgiving one-time hiccups like slow startup times.
+ */
+#define TUNA_NOUTLIERS 3
+
+/**
  * Accumulates runtime information about the performance of a compute chunk.
  * Fill storage with zeros, e.g. from POD zero initialization, to construct or
  * reset an instance.
  */
 typedef struct tuna_chunk {
-    double     outliers[3];  /**< Invariantly-sorted greatest outliers.  */
-    tuna_stats stats;        /**< Accumulated statistics sans outliers. */
+    double     outliers[TUNA_NOUTLIERS];  /**< Invariantly-sorted greatest outliers.  */
+    tuna_stats stats;                     /**< Accumulated statistics sans outliers. */
 } tuna_chunk;
 
 /**


### PR DESCRIPTION
Fixes #31 by replacing the hardcoded value 3 with a named constant
TUNA_NOUTLIERS. This improves code maintainability and makes the
outlier count value explicit and reusable across the codebase.

Changes:
- Added TUNA_NOUTLIERS constant definition in tuna.h
- Updated tuna_chunk struct to use TUNA_NOUTLIERS instead of literal 3
- Modified tests/chunk.c to use TUNA_NOUTLIERS from header