### PR TITLE
Pass git version to Doxygen documentation generation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,19 @@ DX_DOXYGEN_FEATURE([ON])
 DX_DOT_FEATURE([ON])
 DX_HTML_FEATURE([ON])
 DX_MAN_FEATURE([ON])
+dnl Get version from git for Doxygen documentation
+AC_MSG_CHECKING([for git describe version])
+GIT_VERSION=`git describe --always --dirty 2>/dev/null`
+if test -n "$GIT_VERSION"; then
+    AC_MSG_RESULT([$GIT_VERSION])
+else
+    AC_MSG_RESULT([not available, using $PACKAGE_VERSION])
+    GIT_VERSION=$PACKAGE_VERSION
+fi
+AC_SUBST([GIT_VERSION])
 DX_INIT_DOXYGEN([tuna],[doxygen.cfg],[docs])
+dnl Override VERSION with GIT_VERSION for Doxygen
+DX_ENV_APPEND([VERSION], [$GIT_VERSION])
 AC_CONFIG_FILES([
   Makefile
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -27,19 +27,7 @@ DX_DOXYGEN_FEATURE([ON])
 DX_DOT_FEATURE([ON])
 DX_HTML_FEATURE([ON])
 DX_MAN_FEATURE([ON])
-dnl Get version from git for Doxygen documentation
-AC_MSG_CHECKING([for git describe version])
-GIT_VERSION=`git describe --always --dirty 2>/dev/null`
-if test -n "$GIT_VERSION"; then
-    AC_MSG_RESULT([$GIT_VERSION])
-else
-    AC_MSG_RESULT([not available, using $PACKAGE_VERSION])
-    GIT_VERSION=$PACKAGE_VERSION
-fi
-AC_SUBST([GIT_VERSION])
 DX_INIT_DOXYGEN([tuna],[doxygen.cfg],[docs])
-dnl Override VERSION with GIT_VERSION for Doxygen
-DX_ENV_APPEND([VERSION], [$GIT_VERSION])
 AC_CONFIG_FILES([
   Makefile
 ])

--- a/doxygen.am
+++ b/doxygen.am
@@ -141,7 +141,7 @@ doxygen-doc: doxygen-run $(DX_PS_GOAL) $(DX_PDF_GOAL)
 
 @DX_DOCDIR@/@PACKAGE@.tag: $(DX_CONFIG) $(pkginclude_HEADERS)
 	rm -rf @DX_DOCDIR@
-	$(DX_ENV) $(DX_DOXYGEN) $(srcdir)/$(DX_CONFIG)
+	VERSION=`git describe --always --dirty 2>/dev/null || echo $(VERSION)` $(DX_ENV) $(DX_DOXYGEN) $(srcdir)/$(DX_CONFIG)
 
 DX_CLEANFILES = \
     @DX_DOCDIR@/@PACKAGE@.tag \


### PR DESCRIPTION
## Summary
This change enhances the Doxygen documentation build process to include version information from git, falling back to the package version if git is unavailable.

## Key Changes
- Modified the Doxygen build command to set a `VERSION` environment variable before invoking Doxygen
- The `VERSION` variable is populated using `git describe --always --dirty` to capture the current git commit information
- Falls back to the package `$(VERSION)` if git is not available or the command fails
- This allows Doxygen to access version information for inclusion in generated documentation

## Implementation Details
- The git command uses `--always` to ensure a version string is always returned (falling back to commit hash if no tags exist)
- The `--dirty` flag indicates if there are uncommitted changes in the working directory
- Error output is redirected to `/dev/null` to keep the build output clean
- The fallback mechanism ensures the build succeeds even in environments without git