### PR TITLE
Add git tag fetching to CircleCI build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,10 @@ jobs:
       - checkout
 
       - run:
+          name: Fetch git tags for version information
+          command: git fetch --tags --force
+
+      - run:
           name: Update package lists
           command: sudo apt-get -qq update
 
@@ -53,6 +57,10 @@ jobs:
     resource_class: small
     steps:
       - checkout
+
+      - run:
+          name: Fetch git tags for version information
+          command: git fetch --tags --force
 
       - run:
           name: Update package lists


### PR DESCRIPTION
## Summary
Added git tag fetching step to CircleCI configuration to ensure version information is available during builds.

## Changes
- Added `git fetch --tags --force` step to all jobs
- Execute early in the job pipeline, right after checkout

## Details
The new steps fetch git tags with the `--force` flag to ensure that version information is available during the build process. This is typically needed when the build system relies on git tags for versioning (e.g., via tools like `setuptools_scm` or similar version detection mechanisms). Placing these steps immediately after checkout ensures tags are available for all subsequent build steps.